### PR TITLE
navigate user from the homepage of irhpc to docs/intro site of the website

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -6,8 +6,18 @@ import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import styles from './index.module.css';
 import HomepageFeatures from '../components/HomepageFeatures';
 
+//autoNavigate user from front page to docs/intro section of website 
+function autoNavigate(){
+  const section = "docs/intro";
+
+  document.body.style.visibility = "hidden"; //The front page is displayed in a split second before being navigated to intro/doc (we want to hide it)
+  window.location.href = section; //navigation
+}
+
 function HomepageHeader() {
   const {siteConfig} = useDocusaurusContext();
+  autoNavigate();
+
   return (
     <header className={clsx('hero hero--primary', styles.heroBanner)}>
       <div className="container">
@@ -33,6 +43,7 @@ export default function Home() {
       description="Description will go into a meta tag in <head />">
       <HomepageHeader />
       <main>
+
         <HomepageFeatures />
       </main>
     </Layout>

--- a/src/pages/index.module.css
+++ b/src/pages/index.module.css
@@ -5,6 +5,7 @@
  * and scoped locally.
  */
 
+ 
 .heroBanner {
   padding: 4rem 0;
   text-align: center;


### PR DESCRIPTION
added the function "autoNavigate()" located in src/index.js that makes the user automatically go from the homepage to the docs/intro section of the website 